### PR TITLE
Fix a bug: removed select fields in subquery

### DIFF
--- a/lib/clickhouse_ecto/query_string.ex
+++ b/lib/clickhouse_ecto/query_string.ex
@@ -199,7 +199,7 @@ defmodule ClickhouseEcto.QueryString do
   end
 
   def expr(%Ecto.SubQuery{query: query, params: params}, _sources, _query) do
-    query.select.fields |> put_in(params) |> Connection.all()
+    Connection.all(query)
   end
 
   def expr({:fragment, _, [kw]}, _sources, query) when is_list(kw) or tuple_size(kw) == 3 do


### PR DESCRIPTION
Related: #4 

I tried a couple of queries with subqueries and now they all work as expected.

Tbh I'm not sure what was the purpose of `put_in` call in the first place.

I investigated how `Ecto.SubQuery.params` is used in postges adapter, and it serves different purpose there.

Perhaps there's some case that I didn't check.