### PR TITLE
Replace param placeholder from ?<number> to ?

### DIFF
--- a/lib/clickhouse_ecto/query.ex
+++ b/lib/clickhouse_ecto/query.ex
@@ -27,7 +27,7 @@ defmodule ClickhouseEcto.Query do
     #res = [select, from, join, where, group_by, having, order_by, lock]
     #res = [select, from, join, where, group_by, having, order_by, offset | lock]
     res = [select, from, join, where, group_by, having, order_by, limit]
-    
+
     IO.iodata_to_binary(res)
   end
 
@@ -74,7 +74,7 @@ defmodule ClickhouseEcto.Query do
       nil, counter ->
         {"DEFAULT", counter}
       _, counter ->
-        {[?? | Integer.to_string(counter)], counter + 1}
+        {[??], counter + 1}
     end)
   end
 

--- a/lib/clickhouse_ecto/query_string.ex
+++ b/lib/clickhouse_ecto/query_string.ex
@@ -142,8 +142,8 @@ defmodule ClickhouseEcto.QueryString do
     expr(literal, sources, query)
   end
 
-  def expr({:^, [], [ix]}, _sources, _query) do
-    [?? , Integer.to_string(ix + 1)]
+  def expr({:^, [], [_ix]}, _sources, _query) do
+    [??]
   end
 
   def expr({{:., _, [{:&, _, [idx]}, field]}, _, []}, sources, _query) when is_atom(field) do
@@ -174,10 +174,8 @@ defmodule ClickhouseEcto.QueryString do
     "0=1"
   end
 
-  def expr({:in, _, [left, {:^, _, [ix, length]}]}, sources, query) do
-    args =
-        Enum.map(ix+1..ix+length, fn (i) -> [??, to_string(i)] end)
-        |> Enum.intersperse(?,)
+  def expr({:in, _, [left, {:^, _, [_, length]}]}, sources, query) do
+    args = Enum.intersperse(List.duplicate(??, length), ?,)
     [expr(left, sources, query), " IN (", args, ?)]
   end
 

--- a/test/clickhouse_ecto_test.exs
+++ b/test/clickhouse_ecto_test.exs
@@ -6,25 +6,299 @@ defmodule ClickhouseEctoTest do
 
   alias ClickhouseEcto.Connection, as: SQL
 
-
   defmodule Schema do
     use Ecto.Schema
 
-    schema "test" do
-      field :app_id, :integer
-      field :country_id, :integer
-      field :android_id, :string
+    schema "schema" do
+      field :x, :integer
+      field :y, :integer
+      field :z, :integer
     end
+  end
+
+  defp normalize(query, operation \\ :all, counter \\ 0) do
+    {query, _params, _key} = Ecto.Query.Planner.prepare(query, operation, ClickhouseEcto, counter)
+    {query, _} = Ecto.Query.Planner.normalize(query, operation, ClickhouseEcto, counter)
+    query
+  end
+
+
+  defp all(query), do: query |> SQL.all |> IO.iodata_to_binary()
+
+  defp insert(prefx, table, header, rows, on_conflict, returning) do
+    IO.iodata_to_binary SQL.insert(prefx, table, header, rows, on_conflict, returning)
+  end
+
+  test "from" do
+    query = Schema |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0}
+  end
+
+  test "from without schema" do
+    query = "posts" |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT p0."x" FROM "posts" AS p0}
+
+    query = "Posts" |> select([:x]) |> normalize
+    assert all(query) == ~s{SELECT P0."x" FROM "Posts" AS P0}
+
+# FIXME
+#     query = "0posts" |> select([:x]) |> normalize
+#     assert all(query) == ~s{SELECT t0."x" FROM "0posts" AS t0}
+
+#     assert_raise Ecto.QueryError, ~r/MySQL does not support selecting all fields from "posts" without a schema/, fn ->
+#       all from(p in "posts", select: p) |> normalize()
+#     end
+  end
+
+  test "from with subquery" do
+    query = subquery("posts" |> select([r], %{x: r.x, y: r.y})) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM (SELECT p0."x" AS "x", p0."y" AS "y" FROM "posts" AS p0) AS s0}
+
+    query = subquery("posts" |> select([r], %{x: r.x, z: r.y})) |> select([r], r) |> normalize
+    assert all(query) == ~s{SELECT s0."x", s0."z" FROM (SELECT p0."x" AS "x", p0."y" AS "z" FROM "posts" AS p0) AS s0}
   end
 
   test "select" do
     query = Schema |> select([r], {r.x, r.y}) |> normalize
-    assert SQL.all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
 
     query = Schema |> select([r], [r.x, r.y]) |> normalize
-    assert SQL.all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
 
     query = Schema |> select([r], struct(r, [:x, :y])) |> normalize
-    assert SQL.all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+  end
+
+  test "distinct" do
+    query = Schema |> distinct([r], true) |> select([r], {r.x, r.y}) |> normalize
+    assert all(query) == ~s{SELECT DISTINCT s0."x", s0."y" FROM "schema" AS s0}
+
+    query = Schema |> distinct([r], false) |> select([r], {r.x, r.y}) |> normalize
+    assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+
+    query = Schema |> distinct(true) |> select([r], {r.x, r.y}) |> normalize
+    assert all(query) == ~s{SELECT DISTINCT s0."x", s0."y" FROM "schema" AS s0}
+
+    query = Schema |> distinct(false) |> select([r], {r.x, r.y}) |> normalize
+    assert all(query) == ~s{SELECT s0."x", s0."y" FROM "schema" AS s0}
+
+    assert_raise Ecto.QueryError, ~r"DISTINCT ON is not supported", fn ->
+      query = Schema |> distinct([r], [r.x, r.y]) |> select([r], {r.x, r.y}) |> normalize
+      all(query)
+    end
+  end
+
+  test "where" do
+    query = Schema |> where([r], r.x == 42) |> where([r], r.y != 43) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WHERE (s0."x" = 42) AND (s0."y" != 43)}
+  end
+
+  test "or_where" do
+    query = Schema |> or_where([r], r.x == 42) |> or_where([r], r.y != 43) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WHERE (s0."x" = 42) OR (s0."y" != 43)}
+
+    query = Schema |> or_where([r], r.x == 42) |> or_where([r], r.y != 43) |> where([r], r.z == 44) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WHERE ((s0."x" = 42) OR (s0."y" != 43)) AND (s0."z" = 44)}
+  end
+
+  test "order by" do
+    query = Schema |> order_by([r], r.x) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 ORDER BY s0."x"}
+
+    query = Schema |> order_by([r], [r.x, r.y]) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 ORDER BY s0."x", s0."y"}
+
+    query = Schema |> order_by([r], [asc: r.x, desc: r.y]) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 ORDER BY s0."x", s0."y" DESC}
+
+    query = Schema |> order_by([r], []) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0}
+  end
+
+  test "limit and offset" do
+    query = Schema |> limit([r], 3) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 LIMIT 3}
+
+    query = Schema |> offset([r], 5) |> limit([r], 3) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 LIMIT 5, 3}
+  end
+
+  test "string escape" do
+    # FIXME
+    # query = "schema" |> where(foo: "'\\  ") |> select([], true) |> normalize
+    # assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = '''\\\\  ')}
+
+    query = "schema" |> where(foo: "'") |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = '''')}
+  end
+
+  test "binary ops" do
+    query = Schema |> select([r], r.x == 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" = 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x != 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" != 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x <= 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" <= 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x >= 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" >= 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x < 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" < 2 FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x > 2) |> normalize
+    assert all(query) == ~s{SELECT s0."x" > 2 FROM "schema" AS s0}
+  end
+
+  test "is_nil" do
+    query = Schema |> select([r], is_nil(r.x)) |> normalize
+    assert all(query) == ~s{SELECT s0."x" IS NULL FROM "schema" AS s0}
+
+    query = Schema |> select([r], not is_nil(r.x)) |> normalize
+    assert all(query) == ~s{SELECT NOT (s0."x" IS NULL) FROM "schema" AS s0}
+  end
+
+  test "fragments" do
+    query = Schema |> select([r], fragment("lcase(?)", r.x)) |> normalize
+    assert all(query) == ~s{SELECT lcase(s0."x") FROM "schema" AS s0}
+
+    query = Schema |> select([r], r.x) |> where([], fragment("? = \"query\\?\"", ^10)) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 WHERE (? = \"query?\")}
+
+    value = 13
+    query = Schema |> select([r], fragment("lcase(?, ?)", r.x, ^value)) |> normalize
+    assert all(query) == ~s{SELECT lcase(s0."x", ?) FROM "schema" AS s0}
+
+    query = Schema |> select([], fragment(title: 2)) |> normalize
+    assert_raise Ecto.QueryError, fn ->
+      all(query)
+    end
+  end
+
+  test "literals" do
+    query = "schema" |> where(foo: true) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = 1)}
+
+    query = "schema" |> where(foo: false) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = 0)}
+
+    query = "schema" |> where(foo: "abc") |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = 'abc')}
+
+    query = "schema" |> where(foo: 123) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = 123)}
+
+    query = "schema" |> where(foo: 123.0) |> select([], true) |> normalize
+    assert all(query) == ~s{SELECT 'TRUE' FROM "schema" AS s0 WHERE (s0."foo" = 123.0)}
+  end
+
+  test "tagged type" do
+    query = Schema |> select([], type(^"601d74e4-a8d3-4b6e-8365-eddb4c893327", Ecto.UUID)) |> normalize
+    assert all(query) == ~s{SELECT CAST(? AS FixedString(36)) FROM "schema" AS s0}
+  end
+
+  test "string type" do
+    query = Schema |> select([], type(^"test", :string)) |> normalize
+    assert all(query) == ~s{SELECT CAST(? AS String) FROM "schema" AS s0}
+  end
+
+  test "nested expressions" do
+    z = 123
+    query = from(r in Schema, []) |> select([r], r.x > 0 and (r.y > ^(-z)) or true) |> normalize
+    assert all(query) == ~s{SELECT ((s0."x" > 0) AND (s0."y" > ?)) OR 1 FROM "schema" AS s0}
+  end
+
+  test "in expression" do
+    query = Schema |> select([e], 1 in []) |> normalize
+    assert all(query) == ~s{SELECT 0=1 FROM "schema" AS s0}
+
+    query = Schema |> select([e], 1 in [1,e.x,3]) |> normalize
+    assert all(query) == ~s{SELECT 1 IN (1,s0."x",3) FROM "schema" AS s0}
+
+    query = Schema |> select([e], 1 in ^[]) |> normalize
+    assert all(query) == ~s{SELECT 0=1 FROM "schema" AS s0}
+
+    query = Schema |> select([e], 1 in ^[1, 2, 3]) |> normalize
+    assert all(query) == ~s{SELECT 1 IN (?,?,?) FROM "schema" AS s0}
+
+    query = Schema |> select([e], 1 in [1, ^2, 3]) |> normalize
+    assert all(query) == ~s{SELECT 1 IN (1,?,3) FROM "schema" AS s0}
+
+    query = Schema |> select([e], 1 in fragment("foo")) |> normalize
+    assert all(query) == ~s{SELECT 1 = ANY(foo) FROM "schema" AS s0}
+
+    query = Schema |> select([e], e.x == ^0 or e.x in ^[1, 2, 3] or e.x == ^4) |> normalize
+    assert all(query) == ~s{SELECT ((s0."x" = ?) OR (s0."x" IN (?,?,?))) OR (s0."x" = ?) FROM "schema" AS s0}
+  end
+
+  test "having" do
+    query = Schema |> having([p], p.x == p.x) |> select([p], p.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 HAVING (s0."x" = s0."x")}
+
+    query = Schema |> having([p], p.x == p.x) |> having([p], p.y == p.y) |> select([p], [p.y, p.x]) |> normalize
+    assert all(query) == ~s{SELECT s0."y", s0."x" FROM "schema" AS s0 HAVING (s0."x" = s0."x") AND (s0."y" = s0."y")}
+  end
+
+  test "or_having" do
+    query = Schema |> or_having([p], p.x == p.x) |> select([p], p.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 HAVING (s0."x" = s0."x")}
+
+    query = Schema |> or_having([p], p.x == p.x) |> or_having([p], p.y == p.y) |> select([p], [p.y, p.x]) |> normalize
+    assert all(query) == ~s{SELECT s0."y", s0."x" FROM "schema" AS s0 HAVING (s0."x" = s0."x") OR (s0."y" = s0."y")}
+  end
+
+  test "group by" do
+    query = Schema |> group_by([r], r.x) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 GROUP BY s0."x"}
+
+    query = Schema |> group_by([r], 2) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 GROUP BY 2}
+
+    query = Schema |> group_by([r], [r.x, r.y]) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0 GROUP BY s0."x", s0."y"}
+
+    query = Schema |> group_by([r], []) |> select([r], r.x) |> normalize
+    assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0}
+  end
+
+  test "interpolated values" do
+    query = Schema
+            |> select([m], {m.id, ^0})
+            |> where([], fragment("?", ^true))
+            |> where([], fragment("?", ^false))
+            |> having([], fragment("?", ^true))
+            |> having([], fragment("?", ^false))
+            |> group_by([], fragment("?", ^1))
+            |> group_by([], fragment("?", ^2))
+            |> order_by([], fragment("?", ^3))
+            |> order_by([], ^:x)
+            |> limit([], ^4)
+            |> offset([], ^5)
+            |> normalize
+
+    result =
+      ~s{SELECT s0."id", ? FROM "schema" AS s0 } <>
+      ~s{WHERE (?) AND (?) GROUP BY ?, ? HAVING (?) AND (?) } <>
+      ~s{ORDER BY ?, s0."x" LIMIT ?, ?}
+
+    assert all(query) == String.trim(result)
+  end
+
+  # Schema based
+
+  test "insert" do
+    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES (?,?)}
+
+    query = insert(nil, "schema", [:x, :y], [[:x, :y], [nil, :y]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO "schema" ("x","y") VALUES (?,?),(DEFAULT,?)}
+
+    query = insert(nil, "schema", [], [[]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO "schema" () VALUES ()}
+
+    query = insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO "prefix"."schema" () VALUES ()}
   end
 end


### PR DESCRIPTION
## Performance Issues
We've noticed that `ClickhouseEcto` added a lot of overhead to insert times (compared to `db=<num>ms` ecto times)

Profiling revealed that `ClickhouseEcto.Connection.order_params/2` was responsible for almost 25-30% of execution time. ([Regex.replace](https://github.com/appodeal/clickhouse_ecto/blob/master/lib/clickhouse_ecto/connection.ex#L74) calls in  particular)

To eliminate the overhead, we've changed param placeholder format from `?1, ?2, ?3` to `?`. And removed `order_params` as a result, because it was no longer needed.

## Need for ?1, ?2 params

We haven't noticed any regressions after removing ordered params, but to be sure, I've ported mysql unit tests from ecto.

There's a similar code in [mssql ecto adapter](https://github.com/findmypast-oss/mssql_ecto/blob/362cb8dac6df08e316bb08d3247e57215325da31/lib/mssql_ecto/connection.ex#L101) that is required for `DATEADD` mssql functions to work.

But we couldn't find any such cases in clickhouse_ecto, therefore we assumed that it was safe to remove ordered params completely. 

## Test app

I've created a test app to demonstrate the performance differences: https://github.com/scarfacedeb/clickhouse_ecto_test

### A sample of the profiling results

Using `profile.fprof` with the following command:
```
mix profile.fprof -e 'ClickhouseEctoTest.test_insert' --callers=true --no-warmup --sort=own
```

ClickhouseEcto 0.2.4:
```
14:17:06.277 [debug] QUERY OK db=115.2ms decode=0.3ms queue=0.7ms
INSERT INTO "stats" ("fan","ip","temp","temp2","ts","ts_date","user_id") VALUES (?,?,?,?,?,?,?),...

                                                                   CNT    ACC (ms)    OWN (ms)
Total                                                           107537     669.164     522.200

:re.loopexec/7                                                     732       0.000     170.587
:re.do_replace/5                                                    15       1.400       0.203
Regex.run/3                                                          4       0.091       0.091
Regex.match?/2                                                       1       0.023       0.023
Regex.do_replace/4                                                   2     174.019       0.007
Regex.scan/3                                                         1      13.529       0.004
  :re.run/3                                                        755     189.062     170.915  <--
    :re.loopexec/7                                                  40       0.000       0.250
    :re.grun/3                                                      18     188.734       0.109
    :suspend                                                        40       0.909       0.000

Enumerable.List.slice/3                                          61425       0.000     162.325
Enum.slice_any/3                                                   350     180.195       0.895
  Enumerable.List.slice/3                                        61775     180.195     163.220  <--
    Enumerable.List.slice/3                                      61425       0.000     162.325
    :garbage_collect                                                42      10.990      10.990
    :suspend                                                        19       5.985       0.000

....
```

Our fork without `order_params`:

```
14:56:57.239 [debug] QUERY OK db=86.9ms decode=0.1ms queue=45.5ms
INSERT INTO "stats" ("fan","ip","temp","temp2","ts","ts_date","user_id") VALUES (?,?,?,?,?,?,?)...

                                                                   CNT    ACC (ms)    OWN (ms)
Total                                                            38451     270.859     134.829

URI."-encode_www_form/1-lbc$^0/2-0-"/2                            3212       0.000      16.964
URI.encode_www_form/1                                                4      49.227       0.011
  URI."-encode_www_form/1-lbc$^0/2-0-"/2                          3216      49.227      16.975  <--
    URI."-encode_www_form/1-lbc$^0/2-0-"/2                        3212       0.000      16.964
    URI.percent/2                                                 3212      31.839      15.519
    :garbage_collect                                                10       0.378       0.378
    :suspend                                                         2       0.035       0.000

URI."-encode_www_form/1-lbc$^0/2-0-"/2                            3212      31.839      15.519
  URI.percent/2                                                   3212      31.839      15.519  <--
    anonymous fn/1 in URI.encode_www_form/1                       3212      12.036       6.786
    URI.hex/1                                                     1856       3.202       3.182
    :garbage_collect                                                15       0.954       0.954
    :suspend                                                         5       0.128       0.000

....
```