### PR TITLE
Fix a bug: modify/3 uses wrong alter action

### DIFF
--- a/lib/clickhouse_ecto/migration.ex
+++ b/lib/clickhouse_ecto/migration.ex
@@ -110,12 +110,12 @@ defmodule ClickhouseEcto.Migration do
   end
 
   defp column_change(table, {:modify, name, %Reference{} = ref, opts}) do
-    [quote_alter([" ALTER COLUMN ", quote_name(name), ?\s, modify_null(name, opts)], table),
+    [quote_alter([" MODIFY COLUMN ", quote_name(name), ?\s, modify_null(name, opts)], table),
      modify_default(name, ref.type, opts, table, name)]
   end
 
   defp column_change(table, {:modify, name, type, opts}) do
-    [quote_alter([" ALTER COLUMN ", quote_name(name), ?\s, column_type(type, opts),
+    [quote_alter([" MODIFY COLUMN ", quote_name(name), ?\s, column_type(type, opts),
      modify_null(name, opts)], table), modify_default(name, type, opts, table, name)]
   end
 


### PR DESCRIPTION
Hi!

I found that `modify/3` generates wrong query. For example such code

```elixir
alter(table(:table)) do
  modify :column, :integer
end
```

generates such query `ALTER TABLE "table" ALTER COLUMN "column" Int32;`, but according to [documentation](https://clickhouse.yandex/docs/en/query_language/alter/) it should be `ALTER TABLE "table" MODIFY COLUMN "column" Int32;`.

