### PR TITLE
Use extra_applications since we require Elixir v1.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ config :example_app, ExampleApp.ClickHouseRepo,
        pool_size: 30
 ```
 
-Do not forget to add :clickhouse_ecto and :clickhousex to your
-applications:
-
-```elixir
-  def application do
-    [
-      mod: {ExampleApp, []},
-      applications: [
-        :clickhousex, :clickhouse_ecto
-      ]
-    ]
-  end
-```
-
 ## Examples
 
 Example of Ecto model:

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule ClickhouseEcto.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      applications: [:logger, :ecto]
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
By providing :applications default list inferred from dependencies is overwritten and therefore dependants must include unnecessary clickhousex into extra_applications to build releases successfully.

Also see: hashrocket/tilex#172